### PR TITLE
updates trellobo for ruby-trello 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 
 gem "cinch"
-gem "ruby-trello"
+gem "ruby-trello", '~> 0.3.1'
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,10 +4,14 @@ GEM
     addressable (2.2.6)
     cinch (1.1.3)
     json (1.6.2)
+    mime-types (1.17.2)
     oauth (0.4.5)
-    ruby-trello (0.2.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    ruby-trello (0.3.1)
       addressable (~> 2.2.6)
       oauth (~> 0.4.5)
+      rest-client (~> 1.6.7)
       yajl-ruby (>= 1.1.0)
     yajl-ruby (1.1.0)
 
@@ -17,4 +21,4 @@ PLATFORMS
 DEPENDENCIES
   cinch
   json
-  ruby-trello
+  ruby-trello (~> 0.3.1)


### PR DESCRIPTION
Some major changes occurred in the code base between 0.2.1 and 0.3.1. For instance, we now support write operations properly. Not too much has to change in the code however, but we do need a fifth environment variable for trellobo now. Also, please be sure to read the comments in trellobo.rb for instructions on how to generate the access token key which is required for write operations.
